### PR TITLE
Fix broken access modified in MsSqlDatabaseLoggerModule

### DIFF
--- a/SimpleLogger/Logging/Module/MsSqlDatabaseLoggerModule.cs
+++ b/SimpleLogger/Logging/Module/MsSqlDatabaseLoggerModule.cs
@@ -19,7 +19,7 @@ namespace SimpleLogger.Logging.Module
             _tableName = tableName;
         }
 
-        protected override void Initialize()
+        public override void Initialize()
         {
             CreateTable();
         }


### PR DESCRIPTION
In the MsSqlDatabaseLoggerModule the initialize had the "protected" access modifier, should be "public". This PR fixes that :)