### PR TITLE
Filter for log handlers by log message level

### DIFF
--- a/SimpleLogger/Logging/Formatters/DefaultLoggerFormatter.cs
+++ b/SimpleLogger/Logging/Formatters/DefaultLoggerFormatter.cs
@@ -4,7 +4,7 @@ namespace SimpleLogger.Logging.Formatters
     {
         public string ApplyFormat(LogMessage logMessage)
         {
-            return string.Format("{0:dd.MM.yyyy HH:mm}: {1} [line: {2} {3} -> {4}()]: {5}",
+            return string.Format("{0:dd.MM.yyyy HH:mm:ss}: {1} [line: {2} {3} -> {4}()]: {5}",
                             logMessage.DateTime, logMessage.Level, logMessage.LineNumber, logMessage.CallingClass,
                             logMessage.CallingMethod, logMessage.Text);
         }

--- a/SimpleLogger/Logging/ILoggerHandlerManager.cs
+++ b/SimpleLogger/Logging/ILoggerHandlerManager.cs
@@ -1,8 +1,11 @@
-﻿namespace SimpleLogger.Logging
+﻿using System;
+
+namespace SimpleLogger.Logging
 {
     public interface ILoggerHandlerManager
     {
         ILoggerHandlerManager AddHandler(ILoggerHandler loggerHandler);
+        ILoggerHandlerManager AddHandler(ILoggerHandler loggerHandler, Predicate<LogMessage> filter);
 
         bool RemoveHandler(ILoggerHandler loggerHandler);
     }

--- a/SimpleLogger/Logging/LogPublisher.cs
+++ b/SimpleLogger/Logging/LogPublisher.cs
@@ -1,7 +1,20 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace SimpleLogger.Logging
 {
+    internal class FilteredHandler : ILoggerHandler
+    {
+        public Predicate<LogMessage> Filter { get; set; }
+        public ILoggerHandler Handler { get; set; }
+
+        public void Publish(LogMessage logMessage) 
+        {
+            if (Filter(logMessage))
+                Handler.Publish (logMessage);
+        }
+    }
+
     internal class LogPublisher : ILoggerHandlerManager
     {
         private readonly IList<ILoggerHandler> _loggerHandlers;
@@ -11,11 +24,20 @@ namespace SimpleLogger.Logging
         {
             _loggerHandlers = new List<ILoggerHandler>();
             _messages = new List<LogMessage>();
+            StoreLogMessages = false;
+        }
+
+        public LogPublisher(bool storeLogMessages)
+        {
+            _loggerHandlers = new List<ILoggerHandler>();
+            _messages = new List<LogMessage>();
+            StoreLogMessages = storeLogMessages;
         }
 
         public void Publish(LogMessage logMessage)
         {
-            _messages.Add(logMessage);
+            if (StoreLogMessages)
+                _messages.Add(logMessage);
             foreach (var loggerHandler in _loggerHandlers)
                 loggerHandler.Publish(logMessage);
         }
@@ -27,6 +49,17 @@ namespace SimpleLogger.Logging
             return this;
         }
 
+        public ILoggerHandlerManager AddHandler(ILoggerHandler loggerHandler, Predicate<LogMessage> filter)
+        {
+            if ((filter == null) || loggerHandler == null)
+                return this;
+
+            return AddHandler(new FilteredHandler() {
+                Filter = filter,
+                Handler = loggerHandler
+            });
+        }
+
         public bool RemoveHandler(ILoggerHandler loggerHandler)
         {
             return _loggerHandlers.Remove(loggerHandler);
@@ -36,5 +69,11 @@ namespace SimpleLogger.Logging
         {
             get { return _messages; }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="SimpleLogger.Logging.LogPublisher"/> store log messages.
+        /// </summary>
+        /// <value><c>true</c> if store log messages; otherwise, <c>false</c>. By default is <c>false</c></value>
+        public bool StoreLogMessages { get; set; }
     }
 }


### PR DESCRIPTION
Now we can using handlers with filter by log message level:
```php
Logger.LoggerHandlerManager.AddHandler(new ConsoleLoggerHandler(), new Logger.FilterByLevel() { FilteredLevel = Logger.Level.Warning } .Filter)
```
I using this for log messages in current (verbose mode) file handler and only errors (+ severity) file handler.

Another changes: seconds in default formatter + avoid store all log messages in memory (by default).